### PR TITLE
Add CRUD methods to repository interfaces

### DIFF
--- a/src/DafornoMail.Core/Interfaces/Repositories/IEmailAccountRepository.cs
+++ b/src/DafornoMail.Core/Interfaces/Repositories/IEmailAccountRepository.cs
@@ -1,9 +1,21 @@
-﻿using DafornoMail.Core.Models;
+using DafornoMail.Core.Models;
 
 namespace DafornoMail.Core.Interfaces.Repositories
 {
     public interface IEmailAccountRepository
     {
+        // CRUD operations
+        Task<EmailAccount> GetByIdAsync(Guid id);
+        Task<IEnumerable<EmailAccount>> GetAllAsync();
         Task<EmailAccount> AddAsync(EmailAccount account);
+        Task UpdateAsync(EmailAccount account);
+        Task DeleteAsync(Guid id);
+        Task<bool> ExistsAsync(Guid id);
+
+        // Query helpers
+        Task<EmailAccount> GetByEmailAsync(string email);
+        Task<IEnumerable<EmailAccount>> GetByUserIdAsync(string userId);
+        Task SetDefaultAccountAsync(Guid accountId, string userId);
+        Task<EmailAccount> GetDefaultAccountAsync(string userId);
     }
 }

--- a/src/DafornoMail.Core/Interfaces/Repositories/IEmailFolderRepository.cs
+++ b/src/DafornoMail.Core/Interfaces/Repositories/IEmailFolderRepository.cs
@@ -1,7 +1,23 @@
-﻿
+using DafornoMail.Core.Models;
+
 namespace DafornoMail.Core.Interfaces.Repositories
 {
     public interface IEmailFolderRepository
     {
+        // CRUD operations
+        Task<EmailFolder> GetByIdAsync(Guid id);
+        Task<IEnumerable<EmailFolder>> GetAllAsync();
+        Task<EmailFolder> AddAsync(EmailFolder folder);
+        Task UpdateAsync(EmailFolder folder);
+        Task DeleteAsync(Guid id);
+        Task<bool> ExistsAsync(Guid id);
+
+        // Query helpers
+        Task<IEnumerable<EmailFolder>> GetByAccountIdAsync(Guid accountId);
+        Task<EmailFolder> GetByFullNameAsync(Guid accountId, string fullName);
+        Task<IEnumerable<EmailFolder>> GetSystemFoldersAsync(Guid accountId);
+        Task<IEnumerable<EmailFolder>> GetSubFoldersAsync(Guid parentFolderId);
+        Task UpdateLastSyncedAsync(Guid folderId, DateTime lastSynced);
+        Task<int> GetMessageCountAsync(Guid folderId, bool unreadOnly = false);
     }
 }

--- a/src/DafornoMail.Core/Interfaces/Repositories/IEmailMessageRepository.cs
+++ b/src/DafornoMail.Core/Interfaces/Repositories/IEmailMessageRepository.cs
@@ -1,6 +1,33 @@
-﻿namespace DafornoMail.Core.Interfaces.Repositories
+using DafornoMail.Core.Models;
+
+namespace DafornoMail.Core.Interfaces.Repositories
 {
     public interface IEmailMessageRepository
     {
+        // CRUD operations
+        Task<EmailMessage> GetByIdAsync(Guid id);
+        Task<IEnumerable<EmailMessage>> GetAllAsync();
+        Task<EmailMessage> AddAsync(EmailMessage message);
+        Task UpdateAsync(EmailMessage message);
+        Task DeleteAsync(Guid id);
+        Task<bool> ExistsAsync(Guid id);
+
+        // Query helpers
+        Task<EmailMessage> GetByProviderIdAsync(string providerMessageId);
+        Task<IEnumerable<EmailMessage>> GetByAccountIdAsync(Guid accountId);
+        Task<IEnumerable<EmailMessage>> GetByFolderAsync(Guid folderId, int page = 1, int pageSize = 50, string sortBy = "Date", bool sortDescending = true);
+        Task<IEnumerable<EmailMessage>> SearchAsync(Guid accountId, string query, int page = 1, int pageSize = 50, Guid? folderId = null);
+        Task<int> MoveMessagesAsync(IEnumerable<Guid> messageIds, Guid targetFolderId);
+        Task<int> MarkAsReadAsync(IEnumerable<Guid> messageIds, bool read = true);
+        Task<int> MarkAsFlaggedAsync(IEnumerable<Guid> messageIds, bool flagged = true);
+        Task<IEnumerable<EmailMessage>> GetThreadAsync(string threadId, Guid accountId);
+        Task<int> GetCountByFolderAsync(Guid folderId, bool unreadOnly = false);
+        Task<int> GetTotalCountByAccountAsync(Guid accountId);
+        Task<int> DeleteOldMessagesAsync(DateTime cutoffDate);
+        Task<bool> AddLabelToMessageAsync(Guid messageId, string labelName);
+        Task<bool> RemoveLabelFromMessageAsync(Guid messageId, string labelName);
+        Task<IEnumerable<string>> GetExistingProviderIdsAsync(Guid folderId, IEnumerable<string> providerIds);
+        Task<IEnumerable<EmailMessage>> GetMessagesForSyncAsync(Guid folderId, DateTime since);
+        Task DeleteAsync(Guid id, bool permanent);
     }
 }

--- a/src/DafornoMail.Infrastructure/Repositories/EmailMessageRepository.cs
+++ b/src/DafornoMail.Infrastructure/Repositories/EmailMessageRepository.cs
@@ -23,6 +23,13 @@ public class EmailMessageRepository : BaseRepository<EmailMessage>, IEmailMessag
             .FirstOrDefaultAsync(m => m.MessageId == providerMessageId)
             ?? throw new KeyNotFoundException($"Message with provider ID {providerMessageId} not found");
     }
+    public async Task<IEnumerable<EmailMessage>> GetByAccountIdAsync(Guid accountId)
+    {
+        return await _dbSet
+            .Where(m => m.EmailAccountId == accountId && !m.IsDeleted)
+            .ToListAsync();
+    }
+
 
     public async Task<IEnumerable<EmailMessage>> GetByFolderAsync(
         Guid folderId, 


### PR DESCRIPTION
## Summary
- define complete repository interfaces with CRUD and query helpers
- implement `GetByAccountIdAsync` in `EmailMessageRepository`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f007ef9f88326892ad759c0b44b56