### PR TITLE
Implement core email service features

### DIFF
--- a/src/DafornoMail.Core/Interfaces/Repositories/IEmailAccountRepository.cs
+++ b/src/DafornoMail.Core/Interfaces/Repositories/IEmailAccountRepository.cs
@@ -5,5 +5,10 @@ namespace DafornoMail.Core.Interfaces.Repositories
     public interface IEmailAccountRepository
     {
         Task<EmailAccount> AddAsync(EmailAccount account);
+
+        /// <summary>
+        /// Retrieves an account by its identifier.
+        /// </summary>
+        Task<EmailAccount> GetByIdAsync(Guid id);
     }
 }

--- a/src/DafornoMail.Core/Interfaces/Repositories/IEmailFolderRepository.cs
+++ b/src/DafornoMail.Core/Interfaces/Repositories/IEmailFolderRepository.cs
@@ -3,5 +3,9 @@ namespace DafornoMail.Core.Interfaces.Repositories
 {
     public interface IEmailFolderRepository
     {
+        /// <summary>
+        /// Returns folders belonging to the specified account.
+        /// </summary>
+        Task<IEnumerable<EmailFolder>> GetByAccountIdAsync(Guid accountId);
     }
 }

--- a/src/DafornoMail.Core/Interfaces/Repositories/IEmailMessageRepository.cs
+++ b/src/DafornoMail.Core/Interfaces/Repositories/IEmailMessageRepository.cs
@@ -2,5 +2,25 @@
 {
     public interface IEmailMessageRepository
     {
+        Task<IEnumerable<EmailMessage>> GetByFolderAsync(
+            Guid folderId,
+            int page = 1,
+            int pageSize = 50,
+            string sortBy = "Date",
+            bool sortDescending = true);
+
+        Task<IEnumerable<EmailMessage>> SearchAsync(
+            Guid accountId,
+            string query,
+            int page = 1,
+            int pageSize = 50,
+            Guid? folderId = null);
+
+        Task<IEnumerable<EmailMessage>> GetByAccountIdAsync(
+            Guid accountId,
+            int page = 1,
+            int pageSize = 50,
+            string sortBy = "Date",
+            bool sortDescending = true);
     }
 }

--- a/src/DafornoMail.Infrastructure/Repositories/EmailMessageRepository.cs
+++ b/src/DafornoMail.Infrastructure/Repositories/EmailMessageRepository.cs
@@ -4,16 +4,42 @@ using DafornoMail.Core.Models;
 using DafornoMail.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 
 namespace DafornoMail.Infrastructure.Repositories;
 
 public class EmailMessageRepository : BaseRepository<EmailMessage>, IEmailMessageRepository
 {
     public EmailMessageRepository(
-        ApplicationDbContext context, 
+        ApplicationDbContext context,
         ILogger<EmailMessageRepository> logger)
         : base(context, logger)
     {
+    }
+
+    public async Task<IEnumerable<EmailMessage>> GetByAccountIdAsync(
+        Guid accountId,
+        int page = 1,
+        int pageSize = 50,
+        string sortBy = "Date",
+        bool sortDescending = true)
+    {
+        var query = _dbSet.Where(m => m.EmailAccountId == accountId && !m.IsDeleted);
+
+        query = sortBy.ToLower() switch
+        {
+            "subject" => sortDescending
+                ? query.OrderByDescending(m => m.Subject)
+                : query.OrderBy(m => m.Subject),
+            "from" => sortDescending
+                ? query.OrderByDescending(m => m.SenderName ?? m.SenderEmail ?? m.From)
+                : query.OrderBy(m => m.SenderName ?? m.SenderEmail ?? m.From),
+            _ => sortDescending
+                ? query.OrderByDescending(m => m.Date)
+                : query.OrderBy(m => m.Date)
+        };
+
+        return await ApplyPaging(query, page, pageSize).ToListAsync();
     }
 
 

--- a/src/DafornoMail.Infrastructure/Security/KeyVaultService.cs
+++ b/src/DafornoMail.Infrastructure/Security/KeyVaultService.cs
@@ -1,11 +1,12 @@
 ﻿// DafornoMail.Infrastructure/Security/KeyVaultService.cs
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
+using DafornoMail.Core.Interfaces.Services;
 using Microsoft.Extensions.Configuration;
 
 namespace DafornoMail.Infrastructure.Security;
 
-public class KeyVaultService
+public class KeyVaultService : IKeyVaultService
 {
     private readonly SecretClient _secretClient;
     private readonly IConfiguration _configuration;
@@ -56,6 +57,31 @@ public class KeyVaultService
         catch (Exception ex)
         {
             throw new InvalidOperationException($"Failed to delete secret {secretName} from Key Vault", ex);
+        }
+    }
+
+    public async Task<bool> SecretExistsAsync(string secretName)
+    {
+        try
+        {
+            var secret = await _secretClient.GetSecretAsync(secretName);
+            return secret.Value != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task UpdateSecretAsync(string secretName, string secretValue)
+    {
+        try
+        {
+            await _secretClient.SetSecretAsync(secretName, secretValue);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to update secret {secretName} in Key Vault", ex);
         }
     }
 }

--- a/src/DafornoMail.Infrastructure/Services/EmailService.cs
+++ b/src/DafornoMail.Infrastructure/Services/EmailService.cs
@@ -7,6 +7,7 @@ using DafornoMail.Infrastructure.Email;
 using DafornoMail.Infrastructure.Email.Providers;
 using DafornoMail.Infrastructure.Repositories;
 using DafornoMail.Infrastructure.Security;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -100,9 +101,9 @@ public class EmailService : IEmailService
         throw new NotImplementedException();
     }
 
-    public Task<EmailAccount> GetAccountAsync(Guid accountId)
+    public async Task<EmailAccount> GetAccountAsync(Guid accountId)
     {
-        throw new NotImplementedException();
+        return await _accountRepository.GetByIdAsync(accountId);
     }
 
     public Task<IEnumerable<EmailAccount>> GetUserAccountsAsync(string userId)
@@ -110,9 +111,27 @@ public class EmailService : IEmailService
         throw new NotImplementedException();
     }
 
-    public Task<IEnumerable<EmailFolder>> GetFoldersAsync(Guid accountId, bool forceRefresh = false)
+    public async Task<IEnumerable<EmailFolder>> GetFoldersAsync(Guid accountId, bool forceRefresh = false)
     {
-        throw new NotImplementedException();
+        if (!forceRefresh)
+        {
+            return await _folderRepository.GetByAccountIdAsync(accountId);
+        }
+
+        var account = await _accountRepository.GetByIdAsync(accountId);
+        var password = await GetPasswordFromKeyVault(account.KeyVaultSecretName);
+        var provider = CreateProvider(account.Provider);
+
+        try
+        {
+            await provider.ConnectAsync(account.Email, password);
+            var folders = await provider.GetFoldersAsync();
+            return folders;
+        }
+        finally
+        {
+            provider.Disconnect();
+        }
     }
 
     public Task<EmailFolder> GetFolderAsync(Guid folderId)
@@ -140,9 +159,37 @@ public class EmailService : IEmailService
         throw new NotImplementedException();
     }
 
-    public Task<IEnumerable<EmailMessage>> GetMessagesAsync(Guid accountId, Guid? folderId = null, int page = 1, int pageSize = 50, string? searchQuery = null, bool unreadOnly = false, string? sortBy = "Date", bool sortDescending = true)
+    public async Task<IEnumerable<EmailMessage>> GetMessagesAsync(
+        Guid accountId,
+        Guid? folderId = null,
+        int page = 1,
+        int pageSize = 50,
+        string? searchQuery = null,
+        bool unreadOnly = false,
+        string? sortBy = "Date",
+        bool sortDescending = true)
     {
-        throw new NotImplementedException();
+        IEnumerable<EmailMessage> messages;
+
+        if (!string.IsNullOrWhiteSpace(searchQuery))
+        {
+            messages = await _messageRepository.SearchAsync(accountId, searchQuery!, page, pageSize, folderId);
+        }
+        else if (folderId.HasValue)
+        {
+            messages = await _messageRepository.GetByFolderAsync(folderId.Value, page, pageSize, sortBy!, sortDescending);
+        }
+        else
+        {
+            messages = await _messageRepository.GetByAccountIdAsync(accountId, page, pageSize, sortBy!, sortDescending);
+        }
+
+        if (unreadOnly)
+        {
+            messages = messages.Where(m => !m.IsRead);
+        }
+
+        return messages;
     }
 
     public Task<EmailMessage> GetMessageAsync(Guid messageId)

--- a/tests/DafornoMail.Tests/EmailServiceTests.cs
+++ b/tests/DafornoMail.Tests/EmailServiceTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DafornoMail.Core.Interfaces.Repositories;
+using DafornoMail.Core.Interfaces.Services;
+using DafornoMail.Core.Models;
+using DafornoMail.Infrastructure.Email.Providers;
+using DafornoMail.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+public class EmailServiceTests
+{
+    private static EmailService CreateService(
+        Mock<IEmailAccountRepository>? accountRepo = null,
+        Mock<IEmailFolderRepository>? folderRepo = null,
+        Mock<IEmailMessageRepository>? messageRepo = null,
+        Mock<IKeyVaultService>? keyVault = null,
+        Mock<IServiceProvider>? provider = null)
+    {
+        accountRepo ??= new Mock<IEmailAccountRepository>();
+        folderRepo ??= new Mock<IEmailFolderRepository>();
+        messageRepo ??= new Mock<IEmailMessageRepository>();
+        keyVault ??= new Mock<IKeyVaultService>();
+        provider ??= new Mock<IServiceProvider>();
+        var logger = Mock.Of<ILogger<EmailService>>();
+        return new EmailService(
+            accountRepo.Object,
+            folderRepo.Object,
+            messageRepo.Object,
+            keyVault.Object,
+            logger,
+            provider.Object);
+    }
+
+    [Fact]
+    public async Task GetAccountAsync_ReturnsAccount()
+    {
+        var accountId = Guid.NewGuid();
+        var account = new EmailAccount { Id = accountId, Email = "test@example.com" };
+        var repo = new Mock<IEmailAccountRepository>();
+        repo.Setup(r => r.GetByIdAsync(accountId)).ReturnsAsync(account);
+
+        var service = CreateService(accountRepo: repo);
+        var result = await service.GetAccountAsync(accountId);
+        Assert.Equal(accountId, result.Id);
+    }
+
+    [Fact]
+    public async Task GetFoldersAsync_NoRefresh_UsesRepository()
+    {
+        var accountId = Guid.NewGuid();
+        var folders = new List<EmailFolder> { new EmailFolder { Id = Guid.NewGuid(), Name = "Inbox" } };
+        var folderRepo = new Mock<IEmailFolderRepository>();
+        folderRepo.Setup(r => r.GetByAccountIdAsync(accountId)).ReturnsAsync(folders);
+
+        var service = CreateService(folderRepo: folderRepo);
+        var result = await service.GetFoldersAsync(accountId);
+        Assert.Equal(folders, result);
+    }
+
+    [Fact]
+    public async Task GetFoldersAsync_ForceRefresh_UsesProvider()
+    {
+        var accountId = Guid.NewGuid();
+        var account = new EmailAccount { Id = accountId, Email = "a@b.com", Provider = "gmail", KeyVaultSecretName = "sec" };
+        var accountRepo = new Mock<IEmailAccountRepository>();
+        accountRepo.Setup(r => r.GetByIdAsync(accountId)).ReturnsAsync(account);
+
+        var keyVault = new Mock<IKeyVaultService>();
+        keyVault.Setup(k => k.GetSecretAsync(account.KeyVaultSecretName)).ReturnsAsync("pwd");
+
+        var providerMock = new Mock<GmailProvider>(Mock.Of<ILogger<GmailProvider>>()) { CallBase = false };
+        providerMock.Setup(p => p.ConnectAsync(account.Email, "pwd", false, null)).ReturnsAsync(true);
+        providerMock.Setup(p => p.GetFoldersAsync()).ReturnsAsync(new List<EmailFolder>());
+
+        var sp = new Mock<IServiceProvider>();
+        sp.Setup(s => s.GetService(typeof(GmailProvider))).Returns(providerMock.Object);
+
+        var service = CreateService(accountRepo, keyVault: keyVault, provider: sp);
+        await service.GetFoldersAsync(accountId, true);
+
+        providerMock.Verify(p => p.ConnectAsync(account.Email, "pwd", false, null), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMessagesAsync_UsesSearch()
+    {
+        var accountId = Guid.NewGuid();
+        var messages = new List<EmailMessage>();
+        var repo = new Mock<IEmailMessageRepository>();
+        repo.Setup(r => r.SearchAsync(accountId, "q", 1, 50, null)).ReturnsAsync(messages);
+
+        var service = CreateService(messageRepo: repo);
+        var result = await service.GetMessagesAsync(accountId, searchQuery: "q");
+        Assert.Equal(messages, result);
+    }
+
+    [Fact]
+    public async Task GetMessagesAsync_ByFolder()
+    {
+        var accountId = Guid.NewGuid();
+        var folderId = Guid.NewGuid();
+        var messages = new List<EmailMessage>();
+        var repo = new Mock<IEmailMessageRepository>();
+        repo.Setup(r => r.GetByFolderAsync(folderId, 2, 10, "Date", true)).ReturnsAsync(messages);
+
+        var service = CreateService(messageRepo: repo);
+        var result = await service.GetMessagesAsync(accountId, folderId, page: 2, pageSize: 10);
+        Assert.Equal(messages, result);
+    }
+
+    [Fact]
+    public async Task GetMessagesAsync_ByAccount()
+    {
+        var accountId = Guid.NewGuid();
+        var messages = new List<EmailMessage>();
+        var repo = new Mock<IEmailMessageRepository>();
+        repo.Setup(r => r.GetByAccountIdAsync(accountId, 1, 50, "Date", true)).ReturnsAsync(messages);
+
+        var service = CreateService(messageRepo: repo);
+        var result = await service.GetMessagesAsync(accountId);
+        Assert.Equal(messages, result);
+    }
+}


### PR DESCRIPTION
## Summary
- flesh out repository interfaces for accounts, folders, and messages
- implement GetByAccountIdAsync in EmailMessageRepository
- implement KeyVaultService interface
- implement account/folder/message retrieval in EmailService
- add unit tests for EmailService

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f008d5570832697361886e24bbcca